### PR TITLE
Fix connecting to an already running target in VSCode

### DIFF
--- a/unittests/plugin_test.c
+++ b/unittests/plugin_test.c
@@ -304,6 +304,7 @@ void test_parsing(void)
 {
 	mem = (uint8_t *) &dummy_data;
 	test_init();
+	(void)RTOS_GetCurrentThreadId();
 	int ret = RTOS_UpdateThreads();
 	TEST_ASSERT(ret == 0);
 
@@ -312,6 +313,7 @@ void test_parsing(void)
 
 	uint32_t id = RTOS_GetCurrentThreadId();
 	TEST_CHECK(id != 0);
+	TEST_CHECK(id != GDB_NO_THREAD);
 
 	uint32_t id2 = RTOS_GetThreadId(0);
 	uint32_t id1 = RTOS_GetThreadId(1);
@@ -327,6 +329,66 @@ void test_parsing(void)
 
 	// Force clear
 	RTOS_Init(&api, 0);
+}
+
+void check_init(void) {
+	int ret = RTOS_UpdateThreads();
+	TEST_ASSERT(ret == 0);
+
+	uint32_t n = RTOS_GetNumThreads();
+	TEST_CHECK(n == 2);
+
+	uint32_t id = RTOS_GetThreadId(0);
+	TEST_CHECK(id != 0);
+	TEST_CHECK(id != GDB_NO_THREAD);
+}
+
+void check_uninit(void) {
+	int ret = RTOS_UpdateThreads();
+	TEST_ASSERT(ret < 0);
+
+	uint32_t n = RTOS_GetNumThreads();
+	TEST_CHECK(n == 1);
+
+	uint32_t id = RTOS_GetThreadId(0);
+	TEST_CHECK(id == GDB_NO_THREAD);
+}
+
+void test_reconnect(void) {
+	mem = (uint8_t *) &dummy_data;
+	test_init();
+
+	check_uninit();
+
+	uint32_t id = RTOS_GetCurrentThreadId();
+	TEST_CHECK(id != 0);
+	TEST_CHECK(id != GDB_NO_THREAD);
+
+	check_init();
+
+	RTOS_SYMBOLS *symbols = RTOS_GetSymbols();
+
+	check_uninit();
+
+	id = RTOS_GetCurrentThreadId();
+	TEST_CHECK(id != 0);
+	TEST_CHECK(id != GDB_NO_THREAD);
+
+	char display[32];
+	int ret = RTOS_GetThreadDisplay(display, GDB_NO_THREAD);
+	TEST_ASSERT(ret > 0);
+
+	check_uninit();
+
+	id = RTOS_GetCurrentThreadId();
+	TEST_CHECK(id != 0);
+	TEST_CHECK(id != GDB_NO_THREAD);
+
+	check_init();
+
+	// Force clear
+	RTOS_Init(&api, 0);
+
 }
 
 void test_boot(void)
@@ -364,6 +426,7 @@ void test_boot(void)
 TEST_LIST = {
    { "test_init", test_init },
    { "test_parsing", test_parsing},
+   { "test_reconnect", test_reconnect},
    { "test_boot", test_boot},
    { NULL, NULL }     /* zeroed record marking the end of the list */
 };

--- a/zephyr_plugin.c
+++ b/zephyr_plugin.c
@@ -170,6 +170,8 @@ struct thread_t
 
 /** Has RTOS_UpdateThreads run? */
 bool threads_updated = false;
+/** Is GDB initialized? */
+bool gdb_init = false;
 /** Head of thread list */
 struct thread_t *threads_head = NULL;
 /** Currently running thread */
@@ -543,6 +545,12 @@ EXPORT RTOS_SYMBOLS* RTOS_GetSymbols(void) {
 #ifndef _NO_DEBUG_LOG
     api->pfLogOutf("%s()\n", __func__);
 #endif
+    /* When a new GDB client connects, it checks for new symbols
+     * to look up. In this case it also does not know the current
+     * Thread ID, so send dummy data until we know GDB has retrieved
+     * the actual current Thread ID.
+     */
+    gdb_init = false;
     return _Symbols;
 }
 
@@ -550,6 +558,7 @@ EXPORT uint32_t RTOS_GetCurrentThreadId(void) {
 #if !defined(_NO_DEBUG_LOG) && VERBOSE_LOGGING
     api->pfLogOutf("%s()\n", __func__);
 #endif
+    gdb_init = true;
     return current_base;
 }
 
@@ -558,6 +567,10 @@ EXPORT uint32_t RTOS_GetThreadId(uint32_t n) {
 #if !defined(_NO_DEBUG_LOG) && VERBOSE_LOGGING
     api->pfLogOutf("%s(%d)\n", __func__, n);
 #endif
+    if(!gdb_init) {
+        api->pfLogOutf("gdb not initialized\n");
+        return GDB_NO_THREAD;
+    }
     if (t)
         return t->base;
     else
@@ -569,6 +582,13 @@ EXPORT int RTOS_GetThreadDisplay(char *pDisplay, uint32_t threadid) {
 #if !defined(_NO_DEBUG_LOG) && VERBOSE_LOGGING
     api->pfLogOutf("%s(*, %d)\n", __func__, threadid);
 #endif
+    /* When a new GDB client connects, it checks for thread
+     * display with a dummy ID. Send dummy data until we know
+     * GDB has retrieved the actual current Thread ID.
+     */
+    if(GDB_NO_THREAD == threadid) {
+        gdb_init = false;
+    }
     if (t) {
         return sprintf(pDisplay, "%.32s %s PRIO %hhu", t->name, state_to_str(t), t->prio);
     }
@@ -754,6 +774,11 @@ EXPORT int RTOS_UpdateThreads(void) {
     api->pfLogOutf("%s(): Updated %d threads\n", __func__, n_threads());
 #endif
 
+    if( !gdb_init ) {
+        api->pfLogOutf("gdb not initialized\n");
+        return -1;
+    }
+
     return 0;
 }
 
@@ -774,8 +799,9 @@ EXPORT uint32_t RTOS_GetNumThreads(void) {
     uint32_t threads = n_threads();
     /* GDB gets confused if there is no thread running. Consider the current
      * execution context a thread even if the kernel has not started yet.
+     * Further, if GDB has not fully initialized, pretend there is one thread.
      */
-    if( threads == 0 ) {
+    if(( threads == 0 ) || !gdb_init ) {
         threads = 1;
     }
 #if !defined(_NO_DEBUG_LOG) && VERBOSE_LOGGING


### PR DESCRIPTION
When a GDB client first connects, it assumes the current Thread ID is 0xDEAD. Return this dummy Thread ID until GDB retrieves the real current Thread ID. Return to the uninitialized state whenever RTOS_GetSymbols is called or when RTOS_GetThreadDisplay is called with the dummy 0xDEAD thread ID to account for new uninitialized clients connecting.
Without this, VS Code's GDB client either fails to initialize or fails to single step when connecting to a target with the kernel already initialized.